### PR TITLE
Implement map parser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
+-   Implemented the `map` function.
 -   Implemented the `skip_whitespace` function.
 -   Implemented the `whitespace` function.
 -   Implemented the `float` function.


### PR DESCRIPTION
# Pull Request

Issue: #21 

## Description

This PR implements the `map` function that can be used to map the value of a succeeded parser.
