### PR TITLE
Implement guard parser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
+-   Implemented the `guard` function.
 -   Implemented the `map` function.
 -   Implemented the `skip_whitespace` function.
 -   Implemented the `whitespace` function.

--- a/test/pickle_test.gleam
+++ b/test/pickle_test.gleam
@@ -2,6 +2,7 @@ import gleam/string
 import pickle.{
   type Parser, type ParserResult, type ParserTokenMapperCallback, Literal,
   Parser, ParserPosition, Pattern, UnexpectedEof, UnexpectedToken,
+  ValidationError,
 }
 import startest.{describe, it}
 import startest/expect
@@ -26,6 +27,44 @@ pub fn parse_tests() {
       })
       |> expect.to_be_error()
       |> expect.to_equal(UnexpectedEof(Literal("a"), ParserPosition(0, 0)))
+    }),
+  ])
+}
+
+pub fn guard_tests() {
+  describe("pickle/guard", [
+    it(
+      "returns a parser with a mapped failure value when the predicate evaluated to false",
+      fn() {
+        let error_message = "expected value to equal \"123\""
+
+        new_parser("abc", "")
+        |> pickle.token("abc", fn(value, token) { value <> token })
+        |> pickle.guard(fn(value) { value == "123" }, error_message)
+        |> expect.to_be_error()
+        |> expect.to_equal(ValidationError(error_message, ParserPosition(0, 3)))
+      },
+    ),
+    it(
+      "returns a parser with no mapped failure value when the predicate evaluated to true",
+      fn() {
+        new_parser("abc", "")
+        |> pickle.token("abc", fn(value, token) { value <> token })
+        |> pickle.guard(fn(value) { value == "abc" }, "error message")
+        |> expect.to_be_ok()
+        |> expect.to_equal(Parser([], ParserPosition(0, 3), "abc"))
+      },
+    ),
+    it("returns an error when being provided a failed parser", fn() {
+      new_parser("abc", "")
+      |> pickle.token("abd", fn(value, token) { value <> token })
+      |> pickle.guard(fn(value) { value == "abc" }, "error message")
+      |> expect.to_be_error()
+      |> expect.to_equal(UnexpectedToken(
+        Literal("abd"),
+        "abc",
+        ParserPosition(0, 2),
+      ))
     }),
   ])
 }


### PR DESCRIPTION
# Pull Request

Issue: #22 

## Description

This PR implements the `guard` function that can be used to validate the value of a succeeded parser. If the predicate evaluates to `false` a `ValidationError` with a given error message is returned.
