### PR TITLE
Implement one_of parser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 -   Implemented the `skip_whitespace` function.
 -   Implemented the `whitespace` function.
 -   Implemented the `float` function.
--   Implemented the `repeat` function.
 -   Implemented the `skip_until` function.
 -   Implemented the `until` function.
 -   Implemented the `integer` function.
+-   Implemented the `many_concat` function.
 -   Implemented the `many` function.
 -   Implemented the `optional` function.
 -   Implemented the `token` function.
--   Implemented the `input` function.
+-   Implemented the `parser` function.
 
 <!-- scaffolded by git-cliff -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
+-   Implemented the `one_of` function.
 -   Implemented the `guard` function.
 -   Implemented the `map` function.
 -   Implemented the `skip_whitespace` function.

--- a/src/pickle.gleam
+++ b/src/pickle.gleam
@@ -116,12 +116,20 @@ pub fn optional(
 }
 
 pub fn many(
+  prev: ParserResult(List(a)),
+  initial_value: a,
+  parser: ParserCombinatorCallback(a),
+) -> ParserResult(List(a)) {
+  do_many(prev, initial_value, parser)
+}
+
+pub fn many_concat(
   prev: ParserResult(a),
   parser: ParserCombinatorCallback(a),
 ) -> ParserResult(a) {
   case parser(prev) {
     Error(_) -> prev
-    result -> many(result, parser)
+    result -> many_concat(result, parser)
   }
 }
 
@@ -287,14 +295,6 @@ pub fn skip_until(prev: ParserResult(a), token: String) -> ParserResult(a) {
   do_skip_until(prev, token, token |> string.split(""))
 }
 
-pub fn repeat(
-  prev: ParserResult(List(a)),
-  initial_value: a,
-  parser: ParserCombinatorCallback(a),
-) -> ParserResult(List(a)) {
-  do_repeat(prev, initial_value, parser)
-}
-
 pub fn whitespace(
   prev: ParserResult(a),
   to: ParserTokenMapperCallback(a, String),
@@ -369,6 +369,24 @@ fn do_token(
           |> Ok()
           |> do_token(expected_rest)
       }
+  }
+}
+
+fn do_many(
+  prev: ParserResult(List(a)),
+  initial_value: a,
+  parser: ParserCombinatorCallback(a),
+) -> ParserResult(List(a)) {
+  use previous_parser <- result.try(prev)
+
+  case parser(previous_parser |> from(initial_value)) {
+    Error(_) -> prev
+    Ok(many_parser) ->
+      do_many(
+        many_parser |> from([many_parser.value, ..previous_parser.value]),
+        initial_value,
+        parser,
+      )
   }
 }
 
@@ -497,24 +515,6 @@ fn do_skip_until(
           |> Ok()
           |> do_skip_until(until_token, expected_tokens)
       }
-  }
-}
-
-fn do_repeat(
-  prev: ParserResult(List(a)),
-  initial_value: a,
-  parser: ParserCombinatorCallback(a),
-) -> ParserResult(List(a)) {
-  use previous_parser <- result.try(prev)
-
-  case parser(previous_parser |> from(initial_value)) {
-    Error(_) -> prev
-    Ok(repeat_parser) ->
-      do_repeat(
-        repeat_parser |> from([repeat_parser.value, ..previous_parser.value]),
-        initial_value,
-        parser,
-      )
   }
 }
 

--- a/src/pickle.gleam
+++ b/src/pickle.gleam
@@ -327,6 +327,15 @@ pub fn skip_whitespace(prev: ParserResult(a)) -> ParserResult(a) {
   }
 }
 
+pub fn one_of(
+  prev: ParserResult(a),
+  parsers: List(ParserCombinatorCallback(a)),
+) -> ParserResult(a) {
+  use parser <- result.try(prev)
+
+  do_one_of(prev, parser, parsers)
+}
+
 const digit_pattern = "^[0-9]$"
 
 const digit_or_decimal_point_pattern = "^[0-9.]$"
@@ -534,6 +543,21 @@ fn do_whitespace(prev: ParserResult(String)) -> ParserResult(String) {
           )
           |> Ok()
           |> do_whitespace()
+      }
+  }
+}
+
+fn do_one_of(
+  prev: ParserResult(a),
+  entrypoint_parser: Parser(a),
+  parsers: List(ParserCombinatorCallback(a)),
+) -> ParserResult(a) {
+  case parsers {
+    [] -> prev
+    [parser, ..rest] ->
+      case entrypoint_parser |> Ok() |> parser() {
+        Ok(parser) -> Ok(parser)
+        result -> do_one_of(result, entrypoint_parser, rest)
       }
   }
 }

--- a/test/examples/csv_test.gleam
+++ b/test/examples/csv_test.gleam
@@ -44,7 +44,7 @@ fn parse_invoices(
 ) -> ParserResult(List(Invoice)) {
   prev
   |> skip_header()
-  |> pickle.repeat(create_blank_invoice(), parse_invoice)
+  |> pickle.many(create_blank_invoice(), parse_invoice)
 }
 
 fn skip_header(prev: ParserResult(List(Invoice))) -> ParserResult(List(Invoice)) {

--- a/test/examples/date_test.gleam
+++ b/test/examples/date_test.gleam
@@ -122,7 +122,7 @@ fn create_blank_date() -> Date {
 
 fn parse_dates(prev: ParserResult(List(Date))) -> ParserResult(List(Date)) {
   prev
-  |> pickle.repeat(create_blank_date(), parse_date)
+  |> pickle.many(create_blank_date(), parse_date)
 }
 
 fn parse_date(prev: ParserResult(Date)) -> ParserResult(Date) {

--- a/test/pickle_test.gleam
+++ b/test/pickle_test.gleam
@@ -194,14 +194,63 @@ pub fn optional_tests() {
 pub fn many_tests() {
   describe("pickle/many", [
     it("returns a parser that parsed multiple tokens", fn() {
+      new_parser("aaab", [])
+      |> pickle.many("", pickle.token(
+        _,
+        "a",
+        fn(value, token) { value <> token },
+      ))
+      |> expect.to_be_ok()
+      |> expect.to_equal(Parser(["b"], ParserPosition(0, 3), ["a", "a", "a"]))
+    }),
+    it("returns a parser that parsed no tokens", fn() {
+      new_parser("abab", [])
+      |> pickle.many("", pickle.token(
+        _,
+        "aa",
+        fn(value, token) { value <> token },
+      ))
+      |> pickle.token("ab", fn(value, token) { [token, ..value] })
+      |> expect.to_be_ok()
+      |> expect.to_equal(Parser(["a", "b"], ParserPosition(0, 2), ["ab"]))
+    }),
+    it("returns an error when a prior parser failed", fn() {
+      new_parser("aaa", [])
+      |> pickle.token("ab", fn(value, token) { [token, ..value] })
+      |> pickle.many("", pickle.token(
+        _,
+        "a",
+        fn(value, token) { value <> token },
+      ))
+      |> expect.to_be_error()
+      |> expect.to_equal(UnexpectedToken(
+        Literal("ab"),
+        "aa",
+        ParserPosition(0, 1),
+      ))
+    }),
+  ])
+}
+
+pub fn many_concat_tests() {
+  describe("pickle/many_concat", [
+    it("returns a parser that parsed multiple tokens", fn() {
       new_parser("aaab", "Characters: ")
-      |> pickle.many(pickle.token(_, "a", fn(value, token) { value <> token }))
+      |> pickle.many_concat(pickle.token(
+        _,
+        "a",
+        fn(value, token) { value <> token },
+      ))
       |> expect.to_be_ok()
       |> expect.to_equal(Parser(["b"], ParserPosition(0, 3), "Characters: aaa"))
     }),
     it("returns a parser that parsed no tokens", fn() {
       new_parser("abab", "Characters: ")
-      |> pickle.many(pickle.token(_, "aa", fn(value, token) { value <> token }))
+      |> pickle.many_concat(pickle.token(
+        _,
+        "aa",
+        fn(value, token) { value <> token },
+      ))
       |> pickle.token("ab", fn(value, token) { value <> token })
       |> expect.to_be_ok()
       |> expect.to_equal(Parser(
@@ -213,7 +262,11 @@ pub fn many_tests() {
     it("returns an error when a prior parser failed", fn() {
       new_parser("aaa", "Characters: ")
       |> pickle.token("ab", fn(value, token) { value <> token })
-      |> pickle.many(pickle.token(_, "a", fn(value, token) { value <> token }))
+      |> pickle.many_concat(pickle.token(
+        _,
+        "a",
+        fn(value, token) { value <> token },
+      ))
       |> expect.to_be_error()
       |> expect.to_equal(UnexpectedToken(
         Literal("ab"),
@@ -483,7 +536,7 @@ pub fn until_tests() {
       "returns a parser that parsed all tokens until finding the equal sign multiple times",
       fn() {
         new_parser("let test = \"value\";\nlet test2 = \"value2\";", [])
-        |> pickle.many(until_including_token(
+        |> pickle.many_concat(until_including_token(
           _,
           "=",
           fn(value, token) { [token, ..value] },
@@ -543,47 +596,6 @@ pub fn skip_until_tests() {
       |> pickle.skip_until("=")
       |> expect.to_be_error()
       |> expect.to_equal(UnexpectedEof(Literal("="), ParserPosition(0, 15)))
-    }),
-  ])
-}
-
-pub fn repeat_tests() {
-  describe("pickle/repeat", [
-    it("returns a parser that parsed multiple tokens", fn() {
-      new_parser("aaab", [])
-      |> pickle.repeat("", pickle.token(
-        _,
-        "a",
-        fn(value, token) { value <> token },
-      ))
-      |> expect.to_be_ok()
-      |> expect.to_equal(Parser(["b"], ParserPosition(0, 3), ["a", "a", "a"]))
-    }),
-    it("returns a parser that parsed no tokens", fn() {
-      new_parser("abab", [])
-      |> pickle.repeat("", pickle.token(
-        _,
-        "aa",
-        fn(value, token) { value <> token },
-      ))
-      |> pickle.token("ab", fn(value, token) { [token, ..value] })
-      |> expect.to_be_ok()
-      |> expect.to_equal(Parser(["a", "b"], ParserPosition(0, 2), ["ab"]))
-    }),
-    it("returns an error when a prior parser failed", fn() {
-      new_parser("aaa", [])
-      |> pickle.token("ab", fn(value, token) { [token, ..value] })
-      |> pickle.repeat("", pickle.token(
-        _,
-        "a",
-        fn(value, token) { value <> token },
-      ))
-      |> expect.to_be_error()
-      |> expect.to_equal(UnexpectedToken(
-        Literal("ab"),
-        "aa",
-        ParserPosition(0, 1),
-      ))
     }),
   ])
 }


### PR DESCRIPTION
# Pull Request

Issue: #9 

## Description

This PR implements the `one_of` function that tries to parse given tokens using the given parser callbacks. If all parser callbacks fail, the error of the last provided parser callback is returned.

Also, `many` has been renamed to `many_concat`, and `repeat` has been renamed to `many`.
