### PR TITLE
Implement return parser function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+-   Added `pickle/return` to modify the parser's value without consuming any tokens.
 -   Added `pickle/one_of` to parse tokens by trying a set of given parsers.
 -   Added `pickle/guard` to validate the value of the parser.
 -   Added `pickle/map` to map the value of the parser.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 -   Added `pickle/integer` to parse tokens as an integer.
 -   Added `pickle/skip_until` to skip zero to `n` tokens until reaching a specific token.
 -   Added `pickle/until` to parse zero to `n` tokens until reaching a specific token.
--   Added `pickle/many_concat` to parse zero to `n` tokens until the given parser fails.
--   Added `pickle/many` to parse zero to `n` tokens until the given parser fails.
+-   Added `pickle/many` to parse tokens zero to `n` times until the given parser fails.
 -   Added `pickle/optional` to ignore and backtrack the parser in case the given parser fails.
 -   Added `pickle/token` to parse a specific token.
 -   Added `pickle/parse` to parse a set of tokens via a given parser.

--- a/src/pickle.gleam
+++ b/src/pickle.gleam
@@ -327,6 +327,15 @@ pub fn one_of(
   do_one_of(prev, parser, parsers)
 }
 
+pub fn return(
+  prev: ParserResult(a),
+  to: ParserValueMapperCallback(a, a),
+) -> ParserResult(a) {
+  use parser <- result.try(prev)
+
+  from(parser, to(parser.value))
+}
+
 const digit_pattern = "^[0-9]$"
 
 const digit_or_decimal_point_pattern = "^[0-9.]$"

--- a/test/examples/csv_test.gleam
+++ b/test/examples/csv_test.gleam
@@ -39,12 +39,16 @@ fn create_blank_invoice() -> Invoice {
   Invoice(0, "", 0.0)
 }
 
+fn prepend_invoice(invoices: List(Invoice), invoice: Invoice) -> List(Invoice) {
+  [invoice, ..invoices]
+}
+
 fn parse_invoices(
   prev: ParserResult(List(Invoice)),
 ) -> ParserResult(List(Invoice)) {
   prev
   |> skip_header()
-  |> pickle.many(create_blank_invoice(), parse_invoice)
+  |> pickle.many(create_blank_invoice(), parse_invoice, prepend_invoice)
 }
 
 fn skip_header(prev: ParserResult(List(Invoice))) -> ParserResult(List(Invoice)) {

--- a/test/examples/date_test.gleam
+++ b/test/examples/date_test.gleam
@@ -120,9 +120,13 @@ fn create_blank_date() -> Date {
   Date(0, 0, 0, 0, 0, 0)
 }
 
+fn prepend_date(dates: List(Date), date: Date) -> List(Date) {
+  [date, ..dates]
+}
+
 fn parse_dates(prev: ParserResult(List(Date))) -> ParserResult(List(Date)) {
   prev
-  |> pickle.many(create_blank_date(), parse_date)
+  |> pickle.many(create_blank_date(), parse_date, prepend_date)
 }
 
 fn parse_date(prev: ParserResult(Date)) -> ParserResult(Date) {

--- a/test/pickle_test.gleam
+++ b/test/pickle_test.gleam
@@ -720,6 +720,29 @@ pub fn one_of_tests() {
   ])
 }
 
+pub fn return_tests() {
+  describe("pickle/return", [
+    it("returns a parser with a modified value", fn() {
+      new_parser("abc", [])
+      |> pickle.token("abc", fn(value, token) { [token, ..value] })
+      |> pickle.return(fn(value) { ["123", ..value] })
+      |> expect.to_be_ok()
+      |> expect.to_equal(Parser([], ParserPosition(0, 3), ["123", "abc"]))
+    }),
+    it("returns an error when a prior parser failed", fn() {
+      new_parser("abc", [])
+      |> pickle.token("abd", fn(value, token) { [token, ..value] })
+      |> pickle.return(fn(value) { ["123", ..value] })
+      |> expect.to_be_error()
+      |> expect.to_equal(UnexpectedToken(
+        Literal("abd"),
+        "abc",
+        ParserPosition(0, 2),
+      ))
+    }),
+  ])
+}
+
 type Pair {
   Pair(left: String, right: String)
 }

--- a/test/pickle_test.gleam
+++ b/test/pickle_test.gleam
@@ -195,21 +195,21 @@ pub fn many_tests() {
   describe("pickle/many", [
     it("returns a parser that parsed multiple tokens", fn() {
       new_parser("aaab", [])
-      |> pickle.many("", pickle.token(
-        _,
-        "a",
-        fn(value, token) { value <> token },
-      ))
+      |> pickle.many(
+        "",
+        pickle.token(_, "a", fn(value, token) { value <> token }),
+        fn(value, token) { [token, ..value] },
+      )
       |> expect.to_be_ok()
       |> expect.to_equal(Parser(["b"], ParserPosition(0, 3), ["a", "a", "a"]))
     }),
     it("returns a parser that parsed no tokens", fn() {
       new_parser("abab", [])
-      |> pickle.many("", pickle.token(
-        _,
-        "aa",
-        fn(value, token) { value <> token },
-      ))
+      |> pickle.many(
+        "",
+        pickle.token(_, "aa", fn(value, token) { value <> token }),
+        fn(value, token) { [token, ..value] },
+      )
       |> pickle.token("ab", fn(value, token) { [token, ..value] })
       |> expect.to_be_ok()
       |> expect.to_equal(Parser(["a", "b"], ParserPosition(0, 2), ["ab"]))
@@ -217,56 +217,11 @@ pub fn many_tests() {
     it("returns an error when a prior parser failed", fn() {
       new_parser("aaa", [])
       |> pickle.token("ab", fn(value, token) { [token, ..value] })
-      |> pickle.many("", pickle.token(
-        _,
-        "a",
-        fn(value, token) { value <> token },
-      ))
-      |> expect.to_be_error()
-      |> expect.to_equal(UnexpectedToken(
-        Literal("ab"),
-        "aa",
-        ParserPosition(0, 1),
-      ))
-    }),
-  ])
-}
-
-pub fn many_concat_tests() {
-  describe("pickle/many_concat", [
-    it("returns a parser that parsed multiple tokens", fn() {
-      new_parser("aaab", "Characters: ")
-      |> pickle.many_concat(pickle.token(
-        _,
-        "a",
-        fn(value, token) { value <> token },
-      ))
-      |> expect.to_be_ok()
-      |> expect.to_equal(Parser(["b"], ParserPosition(0, 3), "Characters: aaa"))
-    }),
-    it("returns a parser that parsed no tokens", fn() {
-      new_parser("abab", "Characters: ")
-      |> pickle.many_concat(pickle.token(
-        _,
-        "aa",
-        fn(value, token) { value <> token },
-      ))
-      |> pickle.token("ab", fn(value, token) { value <> token })
-      |> expect.to_be_ok()
-      |> expect.to_equal(Parser(
-        ["a", "b"],
-        ParserPosition(0, 2),
-        "Characters: ab",
-      ))
-    }),
-    it("returns an error when a prior parser failed", fn() {
-      new_parser("aaa", "Characters: ")
-      |> pickle.token("ab", fn(value, token) { value <> token })
-      |> pickle.many_concat(pickle.token(
-        _,
-        "a",
-        fn(value, token) { value <> token },
-      ))
+      |> pickle.many(
+        "",
+        pickle.token(_, "a", fn(value, token) { value <> token }),
+        fn(value, token) { [token, ..value] },
+      )
       |> expect.to_be_error()
       |> expect.to_equal(UnexpectedToken(
         Literal("ab"),
@@ -536,11 +491,11 @@ pub fn until_tests() {
       "returns a parser that parsed all tokens until finding the equal sign multiple times",
       fn() {
         new_parser("let test = \"value\";\nlet test2 = \"value2\";", [])
-        |> pickle.many_concat(until_including_token(
-          _,
-          "=",
+        |> pickle.many(
+          "",
+          until_including_token(_, "=", fn(value, token) { value <> token }),
           fn(value, token) { [token, ..value] },
-        ))
+        )
         |> expect.to_be_ok()
         |> expect.to_equal(
           Parser(


### PR DESCRIPTION
# Pull Request

Issue: #36 

## Description

This PR implements the `return` function that can be used to modify the value of the parser. It also replaces `many_concat` in favor of `many`.
