### PR TITLE
Switch to curried API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 -   Added `pickle/many` to parse tokens zero to `n` times until the given parser fails.
 -   Added `pickle/optional` to ignore and backtrack the parser in case the given parser fails.
 -   Added `pickle/token` to parse a specific token.
+-   Added `pickle/then` to chain parsers.
 -   Added `pickle/parse` to parse a set of tokens via a given parser.

--- a/test/examples/csv_test.gleam
+++ b/test/examples/csv_test.gleam
@@ -1,4 +1,4 @@
-import pickle.{type ParserResult}
+import pickle.{type Parser, type ParserFailure}
 import simplifile
 import startest.{describe, it}
 import startest/expect
@@ -18,7 +18,7 @@ pub fn csv_tests() {
         let assert Ok(csv_content) =
           simplifile.read("./test/examples/invoices.csv")
 
-        pickle.parse(csv_content, [], parse_invoices)
+        pickle.parse(csv_content, [], parse_invoices())
         |> expect.to_be_ok()
         |> expect.to_equal([
           Invoice(number: 10, recipient: "Jacob", total: 9.99),
@@ -35,12 +35,6 @@ type Invoice {
   Invoice(number: Int, recipient: String, total: Float)
 }
 
-type InvoicesParserResult =
-  ParserResult(List(Invoice), Nil)
-
-type InvoiceParserResult =
-  ParserResult(Invoice, Nil)
-
 fn create_blank_invoice() -> Invoice {
   Invoice(0, "", 0.0)
 }
@@ -49,39 +43,45 @@ fn prepend_invoice(invoices: List(Invoice), invoice: Invoice) -> List(Invoice) {
   [invoice, ..invoices]
 }
 
-fn parse_invoices(prev: InvoicesParserResult) -> InvoicesParserResult {
-  prev
-  |> skip_header()
-  |> pickle.many(create_blank_invoice(), parse_invoice, prepend_invoice)
+fn parse_invoices() -> fn(Parser(List(Invoice))) ->
+  Result(Parser(List(Invoice)), ParserFailure(Nil)) {
+  skip_header()
+  |> pickle.then(pickle.many(
+    create_blank_invoice(),
+    parse_invoice(),
+    prepend_invoice,
+  ))
 }
 
-fn skip_header(prev: InvoicesParserResult) -> InvoicesParserResult {
-  prev |> pickle.skip_until("\n") |> pickle.token("\n", pickle.ignore_token)
+fn skip_header() -> fn(Parser(List(Invoice))) ->
+  Result(Parser(List(Invoice)), ParserFailure(Nil)) {
+  pickle.skip_until("\n")
+  |> pickle.then(pickle.token("\n", pickle.ignore_token))
 }
 
-fn parse_invoice(prev: InvoiceParserResult) -> InvoiceParserResult {
-  prev
-  |> parse_invoice_number()
-  |> parse_invoice_recipient()
-  |> parse_invoice_total()
+fn parse_invoice() -> fn(Parser(Invoice)) ->
+  Result(Parser(Invoice), ParserFailure(Nil)) {
+  parse_invoice_number()
+  |> pickle.then(parse_invoice_recipient())
+  |> pickle.then(parse_invoice_total())
 }
 
-fn parse_invoice_number(prev: InvoiceParserResult) -> InvoiceParserResult {
-  prev
-  |> pickle.integer(fn(invoice, number) { Invoice(..invoice, number: number) })
-  |> pickle.token(",", pickle.ignore_token)
+fn parse_invoice_number() -> fn(Parser(Invoice)) ->
+  Result(Parser(Invoice), ParserFailure(Nil)) {
+  pickle.integer(fn(invoice, number) { Invoice(..invoice, number: number) })
+  |> pickle.then(pickle.token(",", pickle.ignore_token))
 }
 
-fn parse_invoice_recipient(prev: InvoiceParserResult) -> InvoiceParserResult {
-  prev
-  |> pickle.until(",", fn(invoice, recipient) {
+fn parse_invoice_recipient() -> fn(Parser(Invoice)) ->
+  Result(Parser(Invoice), ParserFailure(Nil)) {
+  pickle.until(",", fn(invoice, recipient) {
     Invoice(..invoice, recipient: recipient)
   })
-  |> pickle.token(",", pickle.ignore_token)
+  |> pickle.then(pickle.token(",", pickle.ignore_token))
 }
 
-fn parse_invoice_total(prev: InvoiceParserResult) -> InvoiceParserResult {
-  prev
-  |> pickle.float(fn(invoice, total) { Invoice(..invoice, total: total) })
-  |> pickle.token("\n", pickle.ignore_token)
+fn parse_invoice_total() -> fn(Parser(Invoice)) ->
+  Result(Parser(Invoice), ParserFailure(Nil)) {
+  pickle.float(fn(invoice, total) { Invoice(..invoice, total: total) })
+  |> pickle.then(pickle.token("\n", pickle.ignore_token))
 }

--- a/test/examples/date_test.gleam
+++ b/test/examples/date_test.gleam
@@ -1,4 +1,4 @@
-import pickle.{type ParserResult, GuardError, ParserPosition}
+import pickle.{type Parser, type ParserFailure, GuardError, ParserPosition}
 import startest.{describe, it}
 import startest/expect
 
@@ -24,7 +24,7 @@ pub fn date_tests() {
           pickle.parse(
             "2020-08-15T20:30:00Z\n2022-09-01T12:00:00Z\n2024-12-10T09:15:00",
             [],
-            parse_dates,
+            parse_dates(),
           )
           |> expect.to_be_ok()
           |> expect.to_equal([
@@ -37,7 +37,7 @@ pub fn date_tests() {
     ]),
     describe("parse_date", [
       it("returns the date provided via the given string", fn() {
-        pickle.parse("2020-08-15T20:30:00Z\n", create_blank_date(), parse_date)
+        pickle.parse("2020-08-15T20:30:00Z", create_blank_date(), parse_date())
         |> expect.to_be_ok()
         |> expect.to_equal(Date(
           year: 2020,
@@ -49,32 +49,32 @@ pub fn date_tests() {
         ))
       }),
       it("returns an error when the year is invalid", fn() {
-        pickle.parse("500-08-15T20:30:00Z", create_blank_date(), parse_date)
+        pickle.parse("500-08-15T20:30:00Z", create_blank_date(), parse_date())
         |> expect.to_be_error()
         |> expect.to_equal(GuardError(InvalidYear, ParserPosition(0, 3)))
       }),
       it("returns an error when the month is invalid", fn() {
-        pickle.parse("2015-40-01T20:30:00", create_blank_date(), parse_date)
+        pickle.parse("2015-40-01T20:30:00", create_blank_date(), parse_date())
         |> expect.to_be_error()
         |> expect.to_equal(GuardError(InvalidMonth, ParserPosition(0, 7)))
       }),
       it("returns an error when the day is invalid", fn() {
-        pickle.parse("2010-10-35T20:30:00", create_blank_date(), parse_date)
+        pickle.parse("2010-10-35T20:30:00", create_blank_date(), parse_date())
         |> expect.to_be_error()
         |> expect.to_equal(GuardError(InvalidDay, ParserPosition(0, 10)))
       }),
       it("returns an error when the hour is invalid", fn() {
-        pickle.parse("2010-10-20T25:30:00", create_blank_date(), parse_date)
+        pickle.parse("2010-10-20T25:30:00", create_blank_date(), parse_date())
         |> expect.to_be_error()
         |> expect.to_equal(GuardError(InvalidHour, ParserPosition(0, 13)))
       }),
       it("returns an error when the minute is invalid", fn() {
-        pickle.parse("2010-10-20T22:72:00", create_blank_date(), parse_date)
+        pickle.parse("2010-10-20T22:72:00", create_blank_date(), parse_date())
         |> expect.to_be_error()
         |> expect.to_equal(GuardError(InvalidMinute, ParserPosition(0, 16)))
       }),
       it("returns an error when the second is invalid", fn() {
-        pickle.parse("2010-10-20T22:30:62", create_blank_date(), parse_date)
+        pickle.parse("2010-10-20T22:30:62", create_blank_date(), parse_date())
         |> expect.to_be_error()
         |> expect.to_equal(GuardError(InvalidSecond, ParserPosition(0, 19)))
       }),
@@ -95,12 +95,6 @@ type InvalidDateError {
   InvalidSecond
 }
 
-type DatesParserResult =
-  ParserResult(List(Date), InvalidDateError)
-
-type DateParserResult =
-  ParserResult(Date, InvalidDateError)
-
 fn create_blank_date() -> Date {
   Date(0, 0, 0, 0, 0, 0)
 }
@@ -109,62 +103,64 @@ fn prepend_date(dates: List(Date), date: Date) -> List(Date) {
   [date, ..dates]
 }
 
-fn parse_dates(prev: DatesParserResult) -> DatesParserResult {
-  prev
-  |> pickle.many(create_blank_date(), parse_date, prepend_date)
+fn parse_dates() -> fn(Parser(List(Date))) ->
+  Result(Parser(List(Date)), ParserFailure(InvalidDateError)) {
+  pickle.many(create_blank_date(), parse_date(), prepend_date)
 }
 
-fn parse_date(prev: DateParserResult) -> DateParserResult {
-  prev
-  |> parse_date_year()
-  |> parse_date_month()
-  |> parse_date_day()
-  |> parse_date_hour()
-  |> parse_date_minute()
-  |> parse_date_second()
+fn parse_date() -> fn(Parser(Date)) ->
+  Result(Parser(Date), ParserFailure(InvalidDateError)) {
+  parse_date_year()
+  |> pickle.then(parse_date_month())
+  |> pickle.then(parse_date_day())
+  |> pickle.then(parse_date_hour())
+  |> pickle.then(parse_date_minute())
+  |> pickle.then(parse_date_second())
 }
 
-fn parse_date_year(prev: DateParserResult) -> DateParserResult {
-  prev
-  |> pickle.integer(fn(date, year) { Date(..date, year: year) })
-  |> pickle.guard(has_valid_year, InvalidYear)
-  |> pickle.token("-", pickle.ignore_token)
+fn parse_date_year() -> fn(Parser(Date)) ->
+  Result(Parser(Date), ParserFailure(InvalidDateError)) {
+  pickle.integer(fn(date, year) { Date(..date, year: year) })
+  |> pickle.then(pickle.guard(has_valid_year, InvalidYear))
+  |> pickle.then(pickle.token("-", pickle.ignore_token))
 }
 
-fn parse_date_month(prev: DateParserResult) -> DateParserResult {
-  prev
-  |> pickle.integer(fn(date, month) { Date(..date, month: month) })
-  |> pickle.guard(has_valid_month, InvalidMonth)
-  |> pickle.token("-", pickle.ignore_token)
+fn parse_date_month() -> fn(Parser(Date)) ->
+  Result(Parser(Date), ParserFailure(InvalidDateError)) {
+  pickle.integer(fn(date, month) { Date(..date, month: month) })
+  |> pickle.then(pickle.guard(has_valid_month, InvalidMonth))
+  |> pickle.then(pickle.token("-", pickle.ignore_token))
 }
 
-fn parse_date_day(prev: DateParserResult) -> DateParserResult {
-  prev
-  |> pickle.integer(fn(date, day) { Date(..date, day: day) })
-  |> pickle.guard(has_valid_day, InvalidDay)
-  |> pickle.token("T", pickle.ignore_token)
+fn parse_date_day() -> fn(Parser(Date)) ->
+  Result(Parser(Date), ParserFailure(InvalidDateError)) {
+  pickle.integer(fn(date, day) { Date(..date, day: day) })
+  |> pickle.then(pickle.guard(has_valid_day, InvalidDay))
+  |> pickle.then(pickle.token("T", pickle.ignore_token))
 }
 
-fn parse_date_hour(prev: DateParserResult) -> DateParserResult {
-  prev
-  |> pickle.integer(fn(date, hour) { Date(..date, hour: hour) })
-  |> pickle.guard(has_valid_hour, InvalidHour)
-  |> pickle.token(":", pickle.ignore_token)
+fn parse_date_hour() -> fn(Parser(Date)) ->
+  Result(Parser(Date), ParserFailure(InvalidDateError)) {
+  pickle.integer(fn(date, hour) { Date(..date, hour: hour) })
+  |> pickle.then(pickle.guard(has_valid_hour, InvalidHour))
+  |> pickle.then(pickle.token(":", pickle.ignore_token))
 }
 
-fn parse_date_minute(prev: DateParserResult) -> DateParserResult {
-  prev
-  |> pickle.integer(fn(date, minute) { Date(..date, minute: minute) })
-  |> pickle.guard(has_valid_minute, InvalidMinute)
-  |> pickle.token(":", pickle.ignore_token)
+fn parse_date_minute() -> fn(Parser(Date)) ->
+  Result(Parser(Date), ParserFailure(InvalidDateError)) {
+  pickle.integer(fn(date, minute) { Date(..date, minute: minute) })
+  |> pickle.then(pickle.guard(has_valid_minute, InvalidMinute))
+  |> pickle.then(pickle.token(":", pickle.ignore_token))
 }
 
-fn parse_date_second(prev: DateParserResult) -> DateParserResult {
-  prev
-  |> pickle.integer(fn(date, second) { Date(..date, second: second) })
-  |> pickle.guard(has_valid_second, InvalidSecond)
-  |> pickle.optional(pickle.token(_, "Z", pickle.ignore_token))
-  |> pickle.one_of([pickle.token(_, "\n", pickle.ignore_token), pickle.eof(_)])
+fn parse_date_second() -> fn(Parser(Date)) ->
+  Result(Parser(Date), ParserFailure(InvalidDateError)) {
+  pickle.integer(fn(date, second) { Date(..date, second: second) })
+  |> pickle.then(pickle.guard(has_valid_second, InvalidSecond))
+  |> pickle.then(pickle.optional(pickle.token("Z", pickle.ignore_token)))
+  |> pickle.then(
+    pickle.one_of([pickle.token("\n", pickle.ignore_token), pickle.eof()]),
+  )
 }
 
 fn has_valid_year(date: Date) -> Bool {


### PR DESCRIPTION
# Pull Request

Issue: #42 

## Description

This PR refactors all parsers to return a function instead of a `Result`. This approach removes the need to check the state of the prior parser in each parser function and also reduces the arity of the parser functions.
