### PR TITLE
Implement not parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+-   Added `pickle/not` to fail if the given parser succeeds.
 -   Added `pickle/skip_whitespace1` to skip one to `n` whitespace tokens.
 -   Added `pickle/whitespace1` to parse one to `n` whitespace tokens.
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -9,7 +9,7 @@ gleam = ">= 1.0.0 and < 2.0.0"
 pages = [
     { title = "CHANGELOG", path = "changelog.html", source = "CHANGELOG.md" },
     { title = "LICENSE", path = "license.html", source = "LICENSE.md" },
-    { title = "&nbsp;", path = "#", source = "" },
+    { title = " ", path = "#", source = "" },
     { title = "Getting Started", path = "docs/getting-started.html", source = "docs/getting_started.md" },
 ]
 

--- a/src/pickle.gleam
+++ b/src/pickle.gleam
@@ -49,6 +49,7 @@ pub type ParserFailure(a) {
   UnexpectedEof(expected_token: ExpectedToken, pos: ParserPosition)
   OneOfError(failures: List(ParserFailure(a)))
   GuardError(error: a, pos: ParserPosition)
+  NotError(error: a, pos: ParserPosition)
   CustomError(error: a)
 }
 
@@ -398,6 +399,21 @@ pub fn eof() -> Parser(a, a, b) {
     case tokens {
       [token, ..] -> UnexpectedToken(Eof, token, pos) |> Error()
       [] -> Ok(parsed)
+    }
+  }
+}
+
+/// Succeeds and backtracks if the given parser fails.
+/// 
+/// The `error` parameter is meant to convey more information
+/// to consumers and its value is wrapped in a `NotError`.
+pub fn not(parser: Parser(a, b, c), error: c) -> Parser(a, a, c) {
+  fn(parsed) {
+    let Parsed(_, pos, _) = parsed
+
+    case parser(parsed) {
+      Error(_) -> Ok(parsed)
+      Ok(_) -> NotError(error, pos) |> Error()
     }
   }
 }


### PR DESCRIPTION
# Pull Request

Issue: #53

## Description

This PR implements the `pickle/not` parser that succeeds and backtracks if the given parser fails.
