### PR TITLE
Implement do parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-07-28
+
+### Added
+
+-   Added `pickle/do` to apply the initial value to a given parser.
+
 ## [0.4.0] - 2024-07-26
 
-## Added
+### Added
 
 -   Added `pickle/any` to parse a single token of any kind.
 -   Added `pickle/skip_until1` to skip one to `n` tokens until the terminator succeeds.
@@ -58,7 +64,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 -   Added `pickle/then` to chain parsers.
 -   Added `pickle/parse` to parse input via a given parser.
 
-[unreleased]: https://github.com/patrik-kuehl/pickle/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/patrik-kuehl/pickle/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/patrik-kuehl/pickle/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/patrik-kuehl/pickle/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/patrik-kuehl/pickle/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/patrik-kuehl/pickle/compare/v0.1.0...v0.2.0

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "pickle"
-version = "0.4.0"
+version = "0.5.0"
 description = "A parser combinator library for Gleam."
 licences = ["MIT"]
 repository = { type = "github", user = "patrik-kuehl", repo = "pickle" }

--- a/test/examples/csv_test.gleam
+++ b/test/examples/csv_test.gleam
@@ -26,14 +26,14 @@ type Invoice {
   Invoice(number: Int, recipient: String, total: Float)
 }
 
-fn create_blank_invoice() -> Invoice {
+fn new_invoice() -> Invoice {
   Invoice(0, "", 0.0)
 }
 
 fn parse_invoices() -> Parser(List(Invoice), List(Invoice), Nil) {
   skip_header()
   |> pickle.then(pickle.many(
-    create_blank_invoice(),
+    new_invoice(),
     parse_invoice(),
     pickle.prepend_to_list,
   ))
@@ -57,10 +57,10 @@ fn parse_invoice_number() -> Parser(Invoice, Invoice, Nil) {
 
 fn parse_invoice_recipient() -> Parser(Invoice, Invoice, Nil) {
   pickle.until(
-    pickle.any(fn(invoice, letter) {
-      Invoice(..invoice, recipient: invoice.recipient <> letter)
-    }),
+    "",
+    pickle.any(pickle.apppend_to_string),
     pickle.string(",", pickle.drop),
+    fn(invoice, recipient) { Invoice(..invoice, recipient: recipient) },
   )
   |> pickle.then(pickle.string(",", pickle.drop))
 }


### PR DESCRIPTION
# Pull Request

Issue: #74

## Description

This PR implements the `pickle/do` parser that applies the initial value to the given parser. This parser can be used to continue consuming tokens while storing a value of a different type than the one the parent parser holds. Most of the time it would be a type an AST type of the parent parser can hold.
