### PR TITLE
Refactor integer parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 -   Added `pickle/hexadecimal_digit` to parse a single hexadecimal digit.
 -   Added `pickle/binary_digit` to parse a single binary digit.
 
+### Changed
+
+-   Changed `pickle/integer` to only parse decimal integers.
+
+### Removed
+
+-   Removed `pickle/decimal_integer` in favor of `pickle/integer`.
+
 ## [0.5.0] - 2024-07-28
 
 ### Added

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,13 +44,12 @@ eventually, we drop it via `pickle/drop`, which is a mapper provided by Pickle t
 We then (no pun intended) use `pickle/then` to combine two parsers. You'll be using this a lot when using Pickle and for
 brevity reasons, `pickle/then` won't be mentioned anymore from this point on.
 
-The prior parser is combined with `pickle/integer` to parse an integer, our `x` value, which we use to create a new
-point with our acquired `x` value. `pickle/integer` parses the given tokens as long as they can be represented as an
-integer, so it doesn't expect an integer of a specific length.
+The prior parser is combined with `pickle/integer` to parse a decimal integer, our `x` value, which we use to create a
+new point with our acquired `x` value. `pickle/integer` parses the given tokens as long as they can be represented as a
+decimal integer, so it doesn't expect an integer of a specific length.
 
-`pickle/integer` supports different numeric formats (binary, decimal, hexadecimal and octal). If you need or want to
-parse an integer of a specific numeric format, you can take a look at Pickle's module documentation. In this guide we'll
-only be using decimal integers, but feel free to play around.
+If you need or want to parse an integer of a different base, you can take a look at Pickle's module documentation. In
+this guide we'll only be using decimal integers, but feel free to play around.
 
 We then continue our adventure with `pickle/string` to parse and drop the comma.
 
@@ -64,6 +63,8 @@ Well done! Now we have a basic parser that we can use to parse points.
 To apply the parser we use `pickle/parse`.
 
 ```gleam
+import gleam/io
+import gleam/string
 import pickle.{type Parser}
 
 /// ...
@@ -92,6 +93,8 @@ Before you write two parsers with a lot of duplication for each shape, take a lo
 it to the prior one we've written.
 
 ```gleam
+import gleam/io
+import gleam/string
 import pickle.{type Parser}
 
 // ...
@@ -119,6 +122,8 @@ opening and closing brackets.
 Let's see it in action.
 
 ```gleam
+import gleam/io
+import gleam/string
 import pickle.{type Parser}
 
 /// ...
@@ -160,6 +165,8 @@ We then need to replace the third type parameter of `Parser` with our custom err
 to expect in case of a validation failure.
 
 ```gleam
+import gleam/io
+import gleam/string
 import pickle.{type Parser}
 
 // ...
@@ -183,6 +190,8 @@ fn point_parser() -> Parser(Point, Point, PointError) {
 Now we need to add some validation. For this purpose we use `pickle/guard`.
 
 ```gleam
+import gleam/io
+import gleam/string
 import pickle.{type Parser}
 
 // ...
@@ -230,6 +239,8 @@ than -10 and greater than 10.
 Trying to parse a point with invalid values now results in a `GuardError`, which contains our error value.
 
 ```gleam
+import gleam/io
+import gleam/string
 import pickle.{type Parser, GuardError}
 
 /// ...
@@ -259,7 +270,9 @@ Pickle happens to offer just the right tool for this job, `pickle/many`. This pa
 `n` times until it fails and is offering us a way to accumulate the collected points.
 
 ```gleam
+import gleam/io
 import gleam/list
+import gleam/string
 import pickle.{type Parser}
 
 // ...
@@ -292,7 +305,9 @@ be a viable option, so you're still able to convey validation issues to the cons
 items with an invalid state before running the validation. The best approach depends on your use case eventually.
 
 ```gleam
+import gleam/io
 import gleam/list
+import gleam/string
 import pickle.{type Parser}
 
 /// ...

--- a/src/pickle.gleam
+++ b/src/pickle.gleam
@@ -243,53 +243,27 @@ pub fn hexadecimal_digit(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
   do_digit(16, HexadecimalDigit, is_hexadecimal_digit, mapper)
 }
 
-/// Parses a binary integer.
-pub fn binary_integer(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
-  do_integer("b", "B", 2, BinaryDigit, is_binary_digit, mapper)
+/// Parses a decimal integer.
+pub fn integer(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
+  do_integer(10, DecimalDigit, is_decimal_digit, mapper)
 }
 
-/// Parses a decimal integer.
-pub fn decimal_integer(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
-  do_integer("d", "D", 10, DecimalDigit, is_decimal_digit, mapper)
+/// Parses a binary integer.
+pub fn binary_integer(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
+  do_integer(2, BinaryDigit, is_binary_digit, mapper)
 }
 
 /// Parses a hexadecimal integer.
 pub fn hexadecimal_integer(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
-  do_integer("x", "X", 16, HexadecimalDigit, is_hexadecimal_digit, mapper)
+  do_integer(16, HexadecimalDigit, is_hexadecimal_digit, mapper)
 }
 
 /// Parses an octal integer.
 pub fn octal_integer(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
-  do_integer("o", "O", 8, OctalDigit, is_octal_digit, mapper)
-}
-
-/// Parses an integer of different numeral systems (binary, decimal, hexadecimal
-/// and octal).
-pub fn integer(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
-  fn(parsed) {
-    let Parsed(tokens, _, _) = parsed
-
-    case tokens {
-      ["0", "b", ..] | ["0", "B", ..] -> parsed |> binary_integer(mapper)
-      ["0", "d", ..] | ["0", "D", ..] -> parsed |> decimal_integer(mapper)
-      ["0", "x", ..] | ["0", "X", ..] -> parsed |> hexadecimal_integer(mapper)
-      ["0", "o", ..] | ["0", "O", ..] -> parsed |> octal_integer(mapper)
-      _ ->
-        parsed
-        |> one_of([
-          decimal_integer(mapper),
-          binary_integer(mapper),
-          hexadecimal_integer(mapper),
-          octal_integer(mapper),
-        ])
-    }
-  }
+  do_integer(8, OctalDigit, is_octal_digit, mapper)
 }
 
 /// Parses a decimal float.
-/// 
-/// This function will be adjusted to support different numeric
-/// formats in later versions.
 pub fn float(mapper: fn(a, Float) -> a) -> Parser(a, a, b) {
   fn(parsed) {
     let Parsed(tokens, pos, _) = parsed
@@ -585,8 +559,6 @@ fn do_digit(
 }
 
 fn do_integer(
-  format_prefix_lowercase: String,
-  format_prefix_uppercase: String,
   base: Int,
   expected_token: ExpectedToken,
   digit_predicate: fn(String) -> Bool,
@@ -596,13 +568,6 @@ fn do_integer(
     let Parsed(tokens, pos, value) = parsed
 
     let #(advanced_parsed, sign) = case tokens {
-      ["0", format_prefix, ..rest]
-        if format_prefix == format_prefix_lowercase
-        || format_prefix == format_prefix_uppercase
-      -> #(
-        Parsed(rest, increment_parser_position(pos, "0" <> format_prefix), ""),
-        "",
-      )
       ["+", ..rest] -> #(
         Parsed(rest, increment_parser_position(pos, "+"), ""),
         "",

--- a/test/examples/point_test.gleam
+++ b/test/examples/point_test.gleam
@@ -1,8 +1,8 @@
 import gleam/list
 import gleeunit/should
 import pickle.{
-  type Parser, BinaryDigit, DecimalDigit, GuardError, HexadecimalDigit,
-  OctalDigit, OneOfError, ParserPosition, String, UnexpectedEof, UnexpectedToken,
+  type Parser, DecimalDigit, GuardError, OneOfError, ParserPosition, String,
+  UnexpectedEof, UnexpectedToken,
 }
 
 pub fn points_parser_test() {
@@ -66,12 +66,7 @@ pub fn point_parser_test() {
   |> should.equal(
     OneOfError([
       UnexpectedToken(String("["), "(", ParserPosition(0, 0)),
-      OneOfError([
-        UnexpectedToken(OctalDigit, ",", ParserPosition(0, 1)),
-        UnexpectedToken(HexadecimalDigit, ",", ParserPosition(0, 1)),
-        UnexpectedToken(BinaryDigit, ",", ParserPosition(0, 1)),
-        UnexpectedToken(DecimalDigit, ",", ParserPosition(0, 1)),
-      ]),
+      UnexpectedToken(DecimalDigit, ",", ParserPosition(0, 1)),
     ]),
   )
 


### PR DESCRIPTION
# Pull Request

Issue: #94 

## Description

This PR refactors the integer parsers. `pickle/integer` won't handle different bases any longer, but only decimal integers. `pickle/decimal_integer` has been removed in favor of `pickle/integer`.
