### PR TITLE
Implement octal digit parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+-   Added `pickle/octal_digit` to parse a single octal digit.
 -   Added `pickle/hexadecimal_digit` to parse a single hexadecimal digit.
 -   Added `pickle/binary_digit` to parse a single binary digit.
 

--- a/src/pickle.gleam
+++ b/src/pickle.gleam
@@ -243,6 +243,11 @@ pub fn hexadecimal_digit(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
   do_digit(16, HexadecimalDigit, is_hexadecimal_digit, mapper)
 }
 
+/// Parses a single octal digit (0-7).
+pub fn octal_digit(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
+  do_digit(8, OctalDigit, is_octal_digit, mapper)
+}
+
 /// Parses a decimal integer.
 pub fn integer(mapper: fn(a, Int) -> a) -> Parser(a, a, b) {
   do_integer(10, DecimalDigit, is_decimal_digit, mapper)

--- a/test/pickle_test.gleam
+++ b/test/pickle_test.gleam
@@ -437,6 +437,45 @@ pub fn hexadecimal_digit_test() {
   |> because("the parser could consume two hexadecimal digits")
 }
 
+pub fn octal_digit_test() {
+  pickle.octal_digit(fn(value, digit) { value + digit })
+  |> pickle.then(pickle.octal_digit(fn(value, digit) { value + digit }))
+  |> pickle.parse("18", 0, _)
+  |> should.be_error()
+  |> should.equal(UnexpectedToken(OctalDigit, "8", ParserPosition(0, 1)))
+  |> because("the second token is not an octal digit")
+
+  pickle.octal_digit(fn(value, integer) { value + integer })
+  |> pickle.parse("9", 0, _)
+  |> should.be_error()
+  |> should.equal(UnexpectedToken(OctalDigit, "9", ParserPosition(0, 0)))
+  |> because("the provided input is not an octal digit")
+
+  pickle.string("ab\nd", pickle.drop)
+  |> pickle.then(pickle.octal_digit(fn(value, integer) { value + integer }))
+  |> pickle.parse("ab\nc110", 0, _)
+  |> should.be_error()
+  |> should.equal(UnexpectedToken(
+    String("ab\nd"),
+    "ab\nc",
+    ParserPosition(1, 0),
+  ))
+  |> because("a prior parser failed")
+
+  pickle.octal_digit(fn(value, integer) { value + integer })
+  |> pickle.parse("", 0, _)
+  |> should.be_error()
+  |> should.equal(UnexpectedEof(OctalDigit, ParserPosition(0, 0)))
+  |> because("no input was left to parse")
+
+  pickle.octal_digit(fn(value, integer) { value + integer })
+  |> pickle.then(pickle.octal_digit(fn(value, digit) { value + digit }))
+  |> pickle.parse("27", 0, _)
+  |> should.be_ok()
+  |> should.equal(9)
+  |> because("the parser could consume two octal digits")
+}
+
 pub fn integer_test() {
   pickle.integer(fn(_, integer) { integer })
   |> pickle.parse("not_an_integer", 0, _)


### PR DESCRIPTION
# Pull Request

Issue: #88

## Description

This PR implements the `pickle/octal_digit` parser to parse a single octal digit.
